### PR TITLE
Avoid clearing menu items (fixes issue #87)

### DIFF
--- a/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/views/AbstractDiagramSourceView.java
+++ b/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/views/AbstractDiagramSourceView.java
@@ -1,12 +1,15 @@
 package net.sourceforge.plantuml.eclipse.views;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.IMenuManager;
@@ -273,7 +276,8 @@ public abstract class AbstractDiagramSourceView extends ViewPart {
 		}
 	}
 
-	protected void addEditorSelectionActions(final IMenuManager menu) {
+	protected List<ActionContributionItem> addEditorSelectionActions(final IMenuManager menu) {
+		List<ActionContributionItem> actions = new ArrayList<ActionContributionItem>();
 		final DiagramTextProvider[] diagramTextProviders = Activator.getDefault().getDiagramTextProviders();
 		final IEditorPart editor = (pinnedTo != null ? pinnedTo : getSite().getPage().getActiveEditor());
 		final ISelectionProvider selectionProvider = editor.getSite().getSelectionProvider();
@@ -283,11 +287,14 @@ public abstract class AbstractDiagramSourceView extends ViewPart {
 					final Iterator<ISelection> selections = ((DiagramTextIteratorProvider) diagramTextProvider).getDiagramText(editor);
 					while (selections.hasNext()) {
 						final ISelection selection = selections.next();
-						menu.add(createEditorSelectionAction(editor, selectionProvider, selection));
+						final ActionContributionItem action = new ActionContributionItem(createEditorSelectionAction(editor, selectionProvider, selection));
+						menu.add(action);
+						actions.add(action);
 					}
 				}
 			}
 		}
+		return actions;
 	}
 
 	private Action createEditorSelectionAction(final IEditorPart editor, final ISelectionProvider selectionProvider, final ISelection selection) {

--- a/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/views/PlantUmlView.java
+++ b/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/views/PlantUmlView.java
@@ -1,7 +1,9 @@
 package net.sourceforge.plantuml.eclipse.views;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
@@ -11,6 +13,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.IMenuListener;
@@ -257,17 +260,22 @@ public class PlantUmlView extends AbstractDiagramSourceView implements ILinkSupp
 
 		final IMenuManager menu = getViewSite().getActionBars().getMenuManager();
 		menu.addMenuListener(new IMenuListener() {
+			private List<ActionContributionItem> actions = new ArrayList<ActionContributionItem>();
+			
 			@Override
 			public void menuAboutToShow(final IMenuManager menu) {
-				addEditorSelectionActions(menu);
+				for (ActionContributionItem action : actions) {
+					menu.remove(action);
+				}
+				actions = addEditorSelectionActions(menu);
 			}
 		});
-		menu.setRemoveAllWhenShown(true);
+		//menu.setRemoveAllWhenShown(true);
 	}
 
 	@Override
-	protected void addEditorSelectionActions(final IMenuManager menu) {
-		super.addEditorSelectionActions(menu);
+	protected List<ActionContributionItem> addEditorSelectionActions(final IMenuManager menu) {
+		return super.addEditorSelectionActions(menu);
 	}
 
 	protected void addZoomActions(final IContributionManager toolBarManager) {


### PR DESCRIPTION
Starting with PlantUml 1.1.22, the `PlantUmlView` removed all menu items
after the menu was shown. This commit changes this behaviour: only those
menu items added programmatically are removed. This allows other plugins
to make menu contributions to the `PlantUmlView`.