### PR TITLE
[WIP] Selections in views can now trigger diagram generation (issue #84)

### DIFF
--- a/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/utils/DiagramTextIteratorProvider.java
+++ b/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/utils/DiagramTextIteratorProvider.java
@@ -3,7 +3,7 @@ package net.sourceforge.plantuml.eclipse.utils;
 import java.util.Iterator;
 
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
 
 /**
  * Used for generating editor selections, from editor contents
@@ -13,10 +13,10 @@ import org.eclipse.ui.IEditorPart;
 public interface DiagramTextIteratorProvider extends DiagramTextProvider {
 
 	/**
-	 * Computes an iterator of editor selections suitable for
-	 * getDiagramText(IEditorPart, ISelection)
-	 * @param editorPart
-	 * @return an iterator of editor selections
+	 * Computes an iterator of workbench part selections suitable for
+	 * getDiagramText(IWorkbenchPart, ISelection)
+	 * @param workbenchPart
+	 * @return an iterator of workbench part selections
 	 */
-	public Iterator<ISelection> getDiagramText(IEditorPart editorPart);
+	public Iterator<ISelection> getDiagramText(IWorkbenchPart workbenchPart);
 }

--- a/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/utils/DiagramTextProvider.java
+++ b/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/utils/DiagramTextProvider.java
@@ -1,7 +1,7 @@
 package net.sourceforge.plantuml.eclipse.utils;
 
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
 
 /**
  * Functionality for generating diagrams from contents of active editors,
@@ -13,10 +13,10 @@ public interface DiagramTextProvider {
 
 	/**
 	 * Tells if the specified editor (or its input) is supported
-	 * @param editorPart
+	 * @param workbenchPart
 	 * @return true if the specified editor (or its input) is supported, false otherwise
 	 */
-	public boolean supportsEditor(IEditorPart editorPart);
+	public boolean supportsPart(IWorkbenchPart workbenchPart);
 
 	/**
 	 * Tells whether the specified editor selection is supported
@@ -27,9 +27,9 @@ public interface DiagramTextProvider {
 
 	/**
 	 * Computes the diagram text for the specific editor part and selection
-	 * @param editorPart
+	 * @param workbenchPart
 	 * @param selection
 	 * @return the corresponding diagram text
 	 */
-	public String getDiagramText(IEditorPart editorPart, ISelection selection);
+	public String getDiagramText(IWorkbenchPart workbenchPart, ISelection selection);
 }

--- a/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/utils/DiagramTextProvider2.java
+++ b/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/utils/DiagramTextProvider2.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
 
 /**
  * Extends DiagramTextProvider with support for generating diagrams from file contents.
@@ -22,14 +22,14 @@ public interface DiagramTextProvider2 extends DiagramTextProvider {
 	public boolean supportsPath(IPath path);
 
 	/**
-	 * Generates the diagram from an editor and its selection,
+	 * Generates the diagram from a workbench part and its selection,
 	 * also considering marker attributes which store info about the previously generated diagram.
-	 * @param editorPart
+	 * @param workbenchPart
 	 * @param selection
 	 * @param markerAttributes
 	 * @return the corresponding diagram text
 	 */
-	public String getDiagramText(IEditorPart editorPart, ISelection selection, Map<String, Object> markerAttributes);
+	public String getDiagramText(IWorkbenchPart workbenchPart, ISelection selection, Map<String, Object> markerAttributes);
 
 	/**
 	 * Generates the diagram from the file contents

--- a/bundles/net.sourceforge.plantuml.jdt/src/net/sourceforge/plantuml/jdt/ui/JdtPlantUmlView.java
+++ b/bundles/net.sourceforge.plantuml.jdt/src/net/sourceforge/plantuml/jdt/ui/JdtPlantUmlView.java
@@ -47,7 +47,7 @@ import net.sourceforge.plantuml.jdt.JdtDiagramTextProvider;
 public class JdtPlantUmlView extends PlantUmlView implements IPropertyChangeListener {
 
 	@Override
-	public boolean isLinkedToActiveEditor() {
+	public boolean isLinkedToActivePart() {
 		return false;
 	}
 

--- a/bundles/net.sourceforge.plantuml.osgi/src/net/sourceforge/plantuml/osgi/ManifestDiagramTextProvider.java
+++ b/bundles/net.sourceforge.plantuml.osgi/src/net/sourceforge/plantuml/osgi/ManifestDiagramTextProvider.java
@@ -14,6 +14,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPathEditorInput;
+import org.eclipse.ui.IWorkbenchPart;
 import org.osgi.scr.Component;
 import org.osgi.scr.util.ScrResourceFactoryImpl;
 
@@ -36,11 +37,14 @@ public class ManifestDiagramTextProvider extends AbstractDiagramTextProvider {
 	}
 	
 	@Override
-	public boolean supportsEditor(IEditorPart editorPart) {
-		if (editorPart.getEditorInput() instanceof IPathEditorInput) {
-			IPathEditorInput editorInput = (IPathEditorInput) editorPart.getEditorInput();
-			if ("MF".equals(editorInput.getPath().getFileExtension())) {
-				return true;
+	public boolean supportsPart(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			IEditorPart editorPart = (IEditorPart) part;
+			if (editorPart.getEditorInput() instanceof IPathEditorInput) {
+				IPathEditorInput editorInput = (IPathEditorInput) editorPart.getEditorInput();
+				if ("MF".equals(editorInput.getPath().getFileExtension())) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/bundles/net.sourceforge.plantuml.osgi/src/net/sourceforge/plantuml/osgi/OsgiComponentDiagramTextProvider.java
+++ b/bundles/net.sourceforge.plantuml.osgi/src/net/sourceforge/plantuml/osgi/OsgiComponentDiagramTextProvider.java
@@ -13,6 +13,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPathEditorInput;
+import org.eclipse.ui.IWorkbenchPart;
 import org.osgi.scr.Component;
 import org.osgi.scr.DocumentRoot;
 import org.osgi.scr.Provide;
@@ -33,11 +34,14 @@ public class OsgiComponentDiagramTextProvider extends AbstractDiagramTextProvide
 	}
 	
 	@Override
-	public boolean supportsEditor(IEditorPart editorPart) {
-		if (editorPart.getEditorInput() instanceof IPathEditorInput) {
-			IPathEditorInput editorInput = (IPathEditorInput) editorPart.getEditorInput();
-			if ("xml".equals(editorInput.getPath().getFileExtension())) {
-				return true;
+	public boolean supportsPart(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			IEditorPart editorPart = (IEditorPart) part;	
+			if (editorPart.getEditorInput() instanceof IPathEditorInput) {
+				IPathEditorInput editorInput = (IPathEditorInput) editorPart.getEditorInput();
+				if ("xml".equals(editorInput.getPath().getFileExtension())) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/bundles/net.sourceforge.plantuml.text/src/net/sourceforge/plantuml/text/AbstractDiagramTextProvider.java
+++ b/bundles/net.sourceforge.plantuml.text/src/net/sourceforge/plantuml/text/AbstractDiagramTextProvider.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
 
 import net.sourceforge.plantuml.eclipse.utils.DiagramTextProvider;
 import net.sourceforge.plantuml.eclipse.utils.PlantumlConstants;
@@ -25,20 +26,21 @@ public abstract class AbstractDiagramTextProvider implements DiagramTextProvider
 	}
 
 	@Override
-	public boolean supportsEditor(final IEditorPart editorPart) {
-		if (editorType != null && (! (editorType.isInstance(editorPart)))) {
+	public boolean supportsPart(final IWorkbenchPart workbenchPart) {
+		if (editorType != null && (! (editorType.isInstance(workbenchPart)))) {
 			return false;
 		}
 		return true;
 	}
 
 	@Override
-	public String getDiagramText(final IEditorPart editorPart, final ISelection selection) {
-		return getDiagramText(editorPart, selection, null);
+	public String getDiagramText(final IWorkbenchPart workbenchPart, final ISelection selection) {
+		return getDiagramText(workbenchPart, selection, null);
 	}
 
-	public String getDiagramText(final IEditorPart editorPart, final ISelection selection, final Map<String, Object> markerAttributes) {
-		if (supportsEditor(editorPart) && (selection == null || supportsSelection(selection))) {
+	public String getDiagramText(final IWorkbenchPart workbenchPart, final ISelection selection, final Map<String, Object> markerAttributes) {
+		if (supportsPart(workbenchPart) && (selection == null || supportsSelection(selection))) {
+			IEditorPart editorPart = (IEditorPart) workbenchPart;
 			final String diagramText = getDiagramText(editorPart, editorPart.getEditorInput(), selection, markerAttributes);
 			return ensureDiagramText(diagramText);
 		}

--- a/bundles/net.sourceforge.plantuml.text/src/net/sourceforge/plantuml/text/TextEditorDiagramTextProvider.java
+++ b/bundles/net.sourceforge.plantuml.text/src/net/sourceforge/plantuml/text/TextEditorDiagramTextProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import net.sourceforge.plantuml.eclipse.utils.DiagramTextIteratorProvider;
@@ -174,9 +175,9 @@ public class TextEditorDiagramTextProvider extends AbstractDiagramTextProvider i
 	// DiagramTextIteratorProvider
 
 	@Override
-	public Iterator<ISelection> getDiagramText(final IEditorPart editorPart) {
+	public Iterator<ISelection> getDiagramText(final IWorkbenchPart editorPart) {
 		final ITextEditor textEditor = (ITextEditor) editorPart;
-		final IDocument document = textEditor.getDocumentProvider().getDocument(editorPart.getEditorInput());
+		final IDocument document = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
 		final FindReplaceDocumentAdapter finder = new FindReplaceDocumentAdapter(document);
 		int selectionStart = 0;
 		final Collection<ISelection> selections = new ArrayList<ISelection>();


### PR DESCRIPTION
This commit generalises how PlantUml handles diagram generation. It now attaches the `DiagramTextChangedListener` not only to editors but also to views. This allows generating diagrams also when elements in, e.g., the Project Explorer are selected. Since the generation is still handled by `DiagramTextProvider` instances, this should have no impact on existing code but allows more flexibility for new use cases. The code also somewhat simplifies the handling of the parts internally, but this needs to be further tested.