### PR TITLE
Fix #93: IllegalArgumentException

### DIFF
--- a/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/Activator.java
+++ b/bundles/net.sourceforge.plantuml.eclipse/src/net/sourceforge/plantuml/eclipse/Activator.java
@@ -178,8 +178,8 @@ public class Activator extends AbstractUIPlugin {
 						}
 						diagramTextProviders.put(diagramTextProvider, priority);
 						final DiagramTextProviderInfo info = new DiagramTextProviderInfo();
-						info.id = ces.getAttribute("id", null);
-						info.label = ces.getAttribute("label", null);
+						info.id = ces.getAttribute("id");
+						info.label = ces.getAttribute("label");
 						this.diagramTextProviderInfo.put(diagramTextProvider, info);
 					} catch (final InvalidRegistryObjectException e) {
 					} catch (final CoreException e) {


### PR DESCRIPTION
Use the non-locale variant of the method to avoid the exception.