### PR TITLE
upgrade tycho to recent version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 target/
+**/.polyglot.build.properties

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.0.0</version>
+    <version>1.4.0</version>
   </extension>
 </extensions>

--- a/releng/net.sourceforge.plantuml.parent/pom.xml
+++ b/releng/net.sourceforge.plantuml.parent/pom.xml
@@ -8,8 +8,8 @@
 	<name>net.sourceforge.plantuml maven parent project</name>
 
 	<properties>
-		<tycho-maven-plugin-version>1.3.0</tycho-maven-plugin-version>
-		<tycho-version>1.3.0</tycho-version>
+		<tycho-maven-plugin-version>1.4.0</tycho-maven-plugin-version>
+		<tycho-version>1.4.0</tycho-version>
 		<xtextVersion>2.9.1</xtextVersion>
 		<xtend-maven-plugin-version>2.9.1</xtend-maven-plugin-version>
 		


### PR DESCRIPTION
Tycho 1.4.0 is the current version and should be used in the build. Also
ignore the temporary files generated by the pomless build extension.